### PR TITLE
Add Postgres provider

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,12 @@ mysql:
     - MYSQL_PASSWORD=password
     - MYSQL_ROOT_PASSWORD=password
     - MYSQL_DATABASE=eventsource
+
+postgres:
+  image: postgres:9.6-alpine
+  ports:
+    - "5432:5432"
+  environment:
+    - POSTGRES_USER=eventsource
+    - POSTGRES_PASSWORD=password
+    - POSTGRES_DB=eventsource

--- a/provider/mysql/infra.go
+++ b/provider/mysql/infra.go
@@ -1,11 +1,11 @@
-package sqlstore
+package mysql
 
 import (
 	"context"
 	"database/sql"
-	"regexp"
 
 	"github.com/go-sql-driver/mysql"
+	"github.com/savaki/eventsource/provider/sqlstore"
 )
 
 const (
@@ -22,12 +22,8 @@ const (
 	mysqlUniqueIndex = `CREATE UNIQUE INDEX idx_{{ .TableName }} ON {{ .TableName }} (id, version)`
 )
 
-var (
-	reTableName = regexp.MustCompile(`\{\{\s*.TableName\s*}}`)
-)
-
 func CreateMySQL(ctx context.Context, db *sql.DB, tableName string) error {
-	createSQL := reTableName.ReplaceAllString(mysqlCreateTable, tableName)
+	createSQL := sqlstore.ReTableName.ReplaceAllString(mysqlCreateTable, tableName)
 
 	_, err := db.ExecContext(ctx, createSQL)
 	if err != nil {
@@ -35,7 +31,7 @@ func CreateMySQL(ctx context.Context, db *sql.DB, tableName string) error {
 	}
 
 	indexes := []string{
-		reTableName.ReplaceAllString(mysqlUniqueIndex, tableName),
+		sqlstore.ReTableName.ReplaceAllString(mysqlUniqueIndex, tableName),
 	}
 
 	for _, createIndexSQL := range indexes {

--- a/provider/mysql/infra_test.go
+++ b/provider/mysql/infra_test.go
@@ -1,4 +1,4 @@
-package sqlstore_test
+package mysql_test
 
 import (
 	"context"
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/savaki/eventsource/provider/sqlstore"
+	"github.com/savaki/eventsource/provider/mysql"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -64,6 +64,6 @@ func TestCreateTable(t *testing.T) {
 	defer db.Close()
 
 	ctx := context.Background()
-	err := sqlstore.CreateMySQL(ctx, db, "thing_events")
+	err := mysql.CreateMySQL(ctx, db, "thing_events")
 	assert.Nil(t, err)
 }

--- a/provider/mysql/store_test.go
+++ b/provider/mysql/store_test.go
@@ -20,10 +20,10 @@ func TestStore_Save(t *testing.T) {
 	db := MustOpen()
 	err := mysql.CreateMySQL(ctx, db, tableName)
 	assert.Nil(t, err)
-	db.Close()
+	defer db.Close()
 
 	// Run provider tests
 
-	store := sqlstore.New(tableName, Open, sqlstore.WithDebug(os.Stderr))
+	store := sqlstore.New(tableName, db, sqlstore.WithDebug(os.Stderr))
 	providertest.TestStore_Save(t, store)
 }

--- a/provider/mysql/store_test.go
+++ b/provider/mysql/store_test.go
@@ -5,22 +5,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/savaki/eventsource"
 	"github.com/savaki/eventsource/provider/mysql"
 	"github.com/savaki/eventsource/provider/providertest"
 	"github.com/savaki/eventsource/provider/sqlstore"
 	"github.com/stretchr/testify/assert"
 )
-
-type EntitySetFirst struct {
-	eventsource.Model
-	First string
-}
-
-type EntitySetLast struct {
-	eventsource.Model
-	Last string
-}
 
 func TestStore_Save(t *testing.T) {
 	ctx := context.Background()

--- a/provider/mysql/store_test.go
+++ b/provider/mysql/store_test.go
@@ -1,0 +1,40 @@
+package mysql_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/savaki/eventsource"
+	"github.com/savaki/eventsource/provider/mysql"
+	"github.com/savaki/eventsource/provider/providertest"
+	"github.com/savaki/eventsource/provider/sqlstore"
+	"github.com/stretchr/testify/assert"
+)
+
+type EntitySetFirst struct {
+	eventsource.Model
+	First string
+}
+
+type EntitySetLast struct {
+	eventsource.Model
+	Last string
+}
+
+func TestStore_Save(t *testing.T) {
+	ctx := context.Background()
+	tableName := "entity_events"
+
+	// Ensure table exists
+
+	db := MustOpen()
+	err := mysql.CreateMySQL(ctx, db, tableName)
+	assert.Nil(t, err)
+	db.Close()
+
+	// Run provider tests
+
+	store := sqlstore.New(tableName, Open, sqlstore.WithDebug(os.Stderr))
+	providertest.TestStore_Save(t, store)
+}

--- a/provider/postgres/infra.go
+++ b/provider/postgres/infra.go
@@ -1,0 +1,44 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/savaki/eventsource/provider/sqlstore"
+)
+
+const (
+	postgresCreateTable = `
+	CREATE TABLE IF NOT EXISTS {{ .TableName }} (
+	    "offset"  BIGSERIAL PRIMARY KEY NOT NULL,
+	    id        VARCHAR(255) NOT NULL,
+	    version   INTEGER NOT NULL,
+	    data      JSON NOT NULL,
+	    at        BIGINT NOT NULL
+	)
+`
+
+	postgresUniqueIndex = `CREATE UNIQUE INDEX IF NOT EXISTS idx_{{ .TableName }} ON {{ .TableName }} (id, version)`
+)
+
+func CreatePostgres(ctx context.Context, db *sql.DB, tableName string) error {
+	createSQL := sqlstore.ReTableName.ReplaceAllString(postgresCreateTable, tableName)
+
+	_, err := db.ExecContext(ctx, createSQL)
+	if err != nil {
+		return err
+	}
+
+	indexes := []string{
+		sqlstore.ReTableName.ReplaceAllString(postgresUniqueIndex, tableName),
+	}
+
+	for _, createIndexSQL := range indexes {
+		_, err := db.ExecContext(ctx, createIndexSQL)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/provider/postgres/infra_test.go
+++ b/provider/postgres/infra_test.go
@@ -1,0 +1,70 @@
+package postgres_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	_ "github.com/lib/pq"
+	"github.com/savaki/eventsource/provider/postgres"
+	"github.com/stretchr/testify/assert"
+)
+
+type Config struct {
+	Username string
+	Password string
+	Hostname string
+	Port     string
+	Database string
+}
+
+func ConnectString(cfg Config) string {
+	return fmt.Sprintf("postgres://%v:%v@%v:%v/%v?sslmode=disable",
+		cfg.Username,
+		cfg.Password,
+		cfg.Hostname,
+		cfg.Port,
+		cfg.Database,
+	)
+}
+
+var connectString = ConnectString(Config{
+	Username: getOrElse("DB_USERNAME", "eventsource"),
+	Password: getOrElse("DB_PASSWORD", "password"),
+	Hostname: getOrElse("DB_HOSTNAME", "127.0.0.1"),
+	Port:     getOrElse("DB_PORT", "5432"),
+	Database: getOrElse("DB_DATABASE", "eventsource"),
+})
+
+func getOrElse(key, defaultValue string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		return defaultValue
+	}
+
+	return v
+}
+
+func Open() (*sql.DB, error) {
+	return sql.Open("postgres", connectString)
+}
+
+func MustOpen() *sql.DB {
+	db, err := Open()
+	if err != nil {
+		log.Fatalln(err)
+	}
+	return db
+}
+
+func TestCreateTable(t *testing.T) {
+	db := MustOpen()
+	defer db.Close()
+
+	ctx := context.Background()
+	err := postgres.CreatePostgres(ctx, db, "thing_events")
+	assert.Nil(t, err)
+}

--- a/provider/postgres/option.go
+++ b/provider/postgres/option.go
@@ -1,0 +1,24 @@
+package postgres
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/savaki/eventsource/provider/sqlstore"
+)
+
+func WithDialectPostgres() sqlstore.Option {
+	return func(s *sqlstore.Store) {
+		s.InsertSQL = sqlToDollar(s.InsertSQL)
+		s.SelectSQL = sqlToDollar(s.SelectSQL)
+		s.SelectVersionSQL = sqlToDollar(s.SelectVersionSQL)
+	}
+}
+
+func sqlToDollar(sql string) string {
+	count := strings.Count(sql, "?")
+	for i := 0; i < count; i++ {
+		sql = strings.Replace(sql, "?", fmt.Sprintf("$%d", i+1), 1)
+	}
+	return sql
+}

--- a/provider/postgres/option.go
+++ b/provider/postgres/option.go
@@ -12,6 +12,7 @@ func WithDialectPostgres() sqlstore.Option {
 		s.InsertSQL = sqlToDollar(s.InsertSQL)
 		s.SelectSQL = sqlToDollar(s.SelectSQL)
 		s.SelectVersionSQL = sqlToDollar(s.SelectVersionSQL)
+		s.SelectAllSQL = sqlToDollar(s.SelectAllSQL)
 	}
 }
 

--- a/provider/postgres/store_test.go
+++ b/provider/postgres/store_test.go
@@ -5,22 +5,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/savaki/eventsource"
 	"github.com/savaki/eventsource/provider/postgres"
 	"github.com/savaki/eventsource/provider/providertest"
 	"github.com/savaki/eventsource/provider/sqlstore"
 	"github.com/stretchr/testify/assert"
 )
-
-type EntitySetFirst struct {
-	eventsource.Model
-	First string
-}
-
-type EntitySetLast struct {
-	eventsource.Model
-	Last string
-}
 
 func TestStore_Save(t *testing.T) {
 	ctx := context.Background()

--- a/provider/postgres/store_test.go
+++ b/provider/postgres/store_test.go
@@ -1,0 +1,40 @@
+package postgres_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/savaki/eventsource"
+	"github.com/savaki/eventsource/provider/postgres"
+	"github.com/savaki/eventsource/provider/providertest"
+	"github.com/savaki/eventsource/provider/sqlstore"
+	"github.com/stretchr/testify/assert"
+)
+
+type EntitySetFirst struct {
+	eventsource.Model
+	First string
+}
+
+type EntitySetLast struct {
+	eventsource.Model
+	Last string
+}
+
+func TestStore_Save(t *testing.T) {
+	ctx := context.Background()
+	tableName := "entity_events"
+
+	// Ensure table exists
+
+	db := MustOpen()
+	err := postgres.CreatePostgres(ctx, db, tableName)
+	assert.Nil(t, err)
+	db.Close()
+
+	// Run provider tests
+
+	store := sqlstore.New(tableName, Open, postgres.WithDialectPostgres(), sqlstore.WithDebug(os.Stderr))
+	providertest.TestStore_Save(t, store)
+}

--- a/provider/postgres/store_test.go
+++ b/provider/postgres/store_test.go
@@ -20,10 +20,10 @@ func TestStore_Save(t *testing.T) {
 	db := MustOpen()
 	err := postgres.CreatePostgres(ctx, db, tableName)
 	assert.Nil(t, err)
-	db.Close()
+	defer db.Close()
 
 	// Run provider tests
 
-	store := sqlstore.New(tableName, Open, postgres.WithDialectPostgres(), sqlstore.WithDebug(os.Stderr))
+	store := sqlstore.New(tableName, db, postgres.WithDialectPostgres(), sqlstore.WithDebug(os.Stderr))
 	providertest.TestStore_Save(t, store)
 }

--- a/provider/providertest/store.go
+++ b/provider/providertest/store.go
@@ -1,14 +1,12 @@
-package sqlstore_test
+package providertest
 
 import (
 	"context"
-	"os"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/savaki/eventsource"
-	"github.com/savaki/eventsource/provider/sqlstore"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,19 +20,7 @@ type EntitySetLast struct {
 	Last string
 }
 
-func TestStore_Save(t *testing.T) {
-	ctx := context.Background()
-	tableName := "entity_events"
-
-	// Ensure table exists
-
-	db := MustOpen()
-	err := sqlstore.CreateMySQL(ctx, db, tableName)
-	assert.Nil(t, err)
-	db.Close()
-
-	// Return
-
+func TestStore_Save(t *testing.T, store eventsource.Store) {
 	aggregateID := strconv.FormatInt(time.Now().UnixNano(), 10)
 	e1 := EntitySetFirst{
 		Model: eventsource.Model{
@@ -59,8 +45,6 @@ func TestStore_Save(t *testing.T) {
 
 	r2, err := serializer.Serialize(e2)
 	assert.Nil(t, err)
-
-	store := sqlstore.New(tableName, Open, sqlstore.WithDebug(os.Stderr))
 
 	err = store.Save(context.Background(), e1.Model.ID, r1, r2)
 	assert.Nil(t, err)

--- a/provider/sqlstore/store.go
+++ b/provider/sqlstore/store.go
@@ -29,9 +29,9 @@ type OpenFunc func() (*sql.DB, error)
 type Store struct {
 	openFunc         OpenFunc
 	tableName        string
-	insertSQL        string
-	selectSQL        string
-	selectVersionSQL string
+	InsertSQL        string
+	SelectSQL        string
+	SelectVersionSQL string
 	debug            bool
 	writer           io.Writer
 }
@@ -51,7 +51,7 @@ func (s *Store) Save(ctx context.Context, aggregateID string, records ...eventso
 	s.log("Saving", len(records), "events.")
 
 	err = func(tx *sql.Tx) error {
-		stmt, err := tx.Prepare(s.insertSQL)
+		stmt, err := tx.Prepare(s.InsertSQL)
 		if err != nil {
 			return err
 		}
@@ -89,9 +89,9 @@ func (s *Store) Fetch(ctx context.Context, aggregateID string, version int) (eve
 	defer db.Close()
 
 	s.log("Reading events with aggregrateID,", aggregateID)
-	query := s.selectSQL
+	query := s.SelectSQL
 	if version > 0 {
-		query = s.selectVersionSQL
+		query = s.SelectVersionSQL
 	}
 	rows, err := db.QueryContext(ctx, query, aggregateID, version)
 	if err != nil {
@@ -144,9 +144,9 @@ func New(tableName string, openFunc OpenFunc, opts ...Option) *Store {
 	s := &Store{
 		openFunc:         openFunc,
 		tableName:        tableName,
-		insertSQL:        insertSQL,
-		selectSQL:        selectSQL,
-		selectVersionSQL: selectVersionSQL,
+		InsertSQL:        insertSQL,
+		SelectSQL:        selectSQL,
+		SelectVersionSQL: selectVersionSQL,
 		writer:           ioutil.Discard,
 	}
 

--- a/provider/sqlstore/store.go
+++ b/provider/sqlstore/store.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math"
+	"regexp"
 	"sort"
 	"time"
 
@@ -17,6 +18,10 @@ const (
 	sqlInsert        = `INSERT INTO {{ .TableName }} (id, version, data, at) VALUES (?, ?, ?, ?)`
 	sqlSelectVersion = `SELECT version, data, at FROM {{ .TableName }} WHERE id = ? and version <= ?`
 	sqlSelect        = `SELECT version, data, at FROM {{ .TableName }} WHERE id = ?`
+)
+
+var (
+	ReTableName = regexp.MustCompile(`\{\{\s*.TableName\s*}}`)
 )
 
 type OpenFunc func() (*sql.DB, error)
@@ -132,9 +137,9 @@ func (s *Store) log(args ...interface{}) {
 }
 
 func New(tableName string, openFunc OpenFunc, opts ...Option) *Store {
-	insertSQL := reTableName.ReplaceAllString(sqlInsert, tableName)
-	selectSQL := reTableName.ReplaceAllString(sqlSelect, tableName)
-	selectVersionSQL := reTableName.ReplaceAllString(sqlSelectVersion, tableName)
+	insertSQL := ReTableName.ReplaceAllString(sqlInsert, tableName)
+	selectSQL := ReTableName.ReplaceAllString(sqlSelect, tableName)
+	selectVersionSQL := ReTableName.ReplaceAllString(sqlSelectVersion, tableName)
 
 	s := &Store{
 		openFunc:         openFunc,

--- a/provider/sqlstore/store.go
+++ b/provider/sqlstore/store.go
@@ -66,7 +66,8 @@ func (s *Store) Save(ctx context.Context, aggregateID string, records ...eventso
 		return tx.Commit()
 	} else {
 		s.log("Failed.  Rolling back transaction.")
-		return tx.Rollback()
+		tx.Rollback()
+		return err
 	}
 }
 

--- a/store.go
+++ b/store.go
@@ -56,6 +56,13 @@ func (m *memoryStore) Save(ctx context.Context, aggregateID string, records ...R
 }
 
 func (m *memoryStore) Fetch(ctx context.Context, aggregateID string, version int) (History, error) {
+	if aggregateID == "" {
+		history := History{}
+		for _, events := range m.eventsByID {
+			history = append(history, events...)
+		}
+		return history, nil
+	}
 	history, ok := m.eventsByID[aggregateID]
 	if !ok {
 		return nil, NewError(nil, AggregateNotFound, "no aggregate found with id, %v", aggregateID)


### PR DESCRIPTION
This pull request contains a provider for Postgres.

As sqlstore currently includes references to "github.com/go-sql-driver/mysql", I've pulled the MySql specific code out into separate package. Unfortunately this does mean the CreateMySQL func has moved and so is a breaking change.

Fixed fetch when version = 0 is requested.